### PR TITLE
fix: move popups to external component to avoid rerender

### DIFF
--- a/src/components/PopupsContainer/index.tsx
+++ b/src/components/PopupsContainer/index.tsx
@@ -1,0 +1,46 @@
+import { useContext, useState } from "react";
+import { ConfigProviderContext } from "../../contexts/ConfigContext";
+import { ConnectionPopup } from "../atoms";
+import { PopupsModule } from "../organisms";
+
+export const PopupsContainer = () => {
+    const {
+        confirmModal,
+        isConnected,
+        linkExplorer,
+        onConnectWallet,
+        progressModal,
+        setConfirmModal,
+        setProgressModal,
+        setShowConnectionPopup,
+        showConnectionPopup,
+    } = useContext(ConfigProviderContext);
+
+    return (
+        <>
+            <PopupsModule isOpen={progressModal} handleOpen={setProgressModal} progress>
+                Check the progress of your{" "}
+                <a href={linkExplorer} target="_blank">
+                    deploy
+                </a>
+                .
+            </PopupsModule>
+            <PopupsModule isOpen={confirmModal} handleOpen={setConfirmModal} progress={false}>
+                Your{" "}
+                <a href={linkExplorer} target="_blank">
+                    deploy
+                </a>{" "}
+                was successful.
+            </PopupsModule>
+            <ConnectionPopup
+                isConnected={isConnected}
+                isOpened={showConnectionPopup}
+                onToggle={() => setShowConnectionPopup(!showConnectionPopup)}
+                title="Connect your wallet to CasperSwap"
+                onClose={() => setShowConnectionPopup(false)}
+                onConnect={onConnectWallet}
+                showButton={false}
+            />
+        </>
+    );
+}

--- a/src/contexts/ConfigContext/index.tsx
+++ b/src/contexts/ConfigContext/index.tsx
@@ -7,7 +7,6 @@ import React, {
   useReducer,
   useState,
 } from 'react';
-import { PopupsModule } from '../../components/organisms';
 import { NODE_ADDRESS, NotificationType } from '../../constant';
 
 import {
@@ -48,15 +47,13 @@ import {
 
 import { signAndDeployAllowance } from '../../commons/deploys';
 import { ConfigState } from '../../reducers/ConfigReducers';
-import { Row, useAsyncDebounce, useGlobalFilter, useSortBy, useTable } from 'react-table';
-import { ConnectionPopup } from '../../components/atoms';
+import { Row, useAsyncDebounce } from 'react-table';
 import { notificationStore } from '../../store/store';
 import { ERROR_BLOCKCHAIN } from "../../constant/errors";
 import { getPath } from '../../commons/calculations'
 import { TableInstance } from "../../components/organisms/PoolModule";
 import { getPairData } from "../../commons/api/ApolloQueries";
 import store from "store2";
-import { stringify } from 'querystring';
 
 type MaybeWallet = Wallet | undefined;
 
@@ -83,6 +80,11 @@ export interface ConfigContext {
     contractHash: string
   ) => Promise<boolean>;
   pairState?: PairState;
+  confirmModal: boolean;
+  linkExplorer: string;
+  progressModal: boolean;
+  setShowConnectionPopup: (show: boolean) => void;
+  showConnectionPopup: boolean;
 
   // To Delete
   poolColumns?: any[];
@@ -535,7 +537,7 @@ export const ConfigContextWithReducer = ({
     }
   }
 
-  const { isConnected, walletSelected, slippageToleranceSelected, mainPurse } =
+  const { isConnected, slippageToleranceSelected, mainPurse } =
     state;
 
   const handleResize = () => {
@@ -1179,41 +1181,15 @@ export const ConfigContextWithReducer = ({
         filterDataReload,
         mapExpandedRows,
         setMapExpandedRows,
-        changeRowPriority
+        changeRowPriority,
+        confirmModal,
+        linkExplorer,
+        progressModal,
+        setShowConnectionPopup,
+        showConnectionPopup
       }}
     >
       {children}
-      <PopupsModule
-        isOpen={progressModal}
-        handleOpen={setProgressModal}
-        progress
-      >
-        Check the progress of your{' '}
-        <a href={linkExplorer} target='_blank'>
-          deploy
-        </a>
-        .
-      </PopupsModule>
-      <PopupsModule
-        isOpen={confirmModal}
-        handleOpen={setConfirmModal}
-        progress={false}
-      >
-        Your{' '}
-        <a href={linkExplorer} target='_blank'>
-          deploy
-        </a>{' '}
-        was successful.
-      </PopupsModule>
-      <ConnectionPopup
-        isConnected={isConnected}
-        isOpened={showConnectionPopup}
-        onToggle={() => setShowConnectionPopup(!showConnectionPopup)}
-        title='Connect your wallet to CasperSwap'
-        onClose={() => setShowConnectionPopup(false)}
-        onConnect={onConnectWallet}
-        showButton={false}
-      />
     </ConfigProviderContext.Provider>
   );
 };

--- a/src/contexts/index.tsx
+++ b/src/contexts/index.tsx
@@ -10,6 +10,7 @@ import { ConfigContextWithReducer } from './ConfigContext'
 import { ProgressBarContextWithReducer } from "./ProgressBarContext"
 import { SwapContext } from "./SwapContext";
 import { NotificationSystem } from '../components/organisms'
+import { PopupsContainer } from '../components/PopupsContainer'
 
 
 export const BigContext = ({ children }: { children: ReactNode }) => {
@@ -35,6 +36,7 @@ export const BigContext = ({ children }: { children: ReactNode }) => {
             </ProgressBarContextWithReducer>
           </LiquidityContext>
         </SwapContext>
+        <PopupsContainer/>
       </ConfigContextWithReducer>
     </ThemeContext>
   )


### PR DESCRIPTION
The default behavior of the context is to render everything below the tree whenever the data value changes. For this reason, in the component that contains the context provider, only the children property must exist.
<img width="592" alt="Screen Shot 2023-02-09 at 12 56 11" src="https://user-images.githubusercontent.com/88843619/217865933-c3e8c087-9be9-48ec-adc2-9405c3b6688b.png">

So, we move all popups to an external component:
<img width="615" alt="Screen Shot 2023-02-09 at 12 58 48" src="https://user-images.githubusercontent.com/88843619/217866784-cf1bc0dc-788e-4564-b7ba-4a70db532a41.png">

