### PR TITLE
Fix/remove liquidity when zero percent

### DIFF
--- a/src/components/templates/LiquidityPoolTemplate/index.tsx
+++ b/src/components/templates/LiquidityPoolTemplate/index.tsx
@@ -109,6 +109,7 @@ export const LiquidityPoolTemplate = ({ isMobile }) => {
   const [removeLiquidityToggle, setRemoveLiquidityToggle] = useState(true)
   const { slippageTolerance, updateSlippageTolerance } = globalStore()
   const [gasFee, gasFeeSetter] = useState<number>(gasPriceSelectedForLiquidity)
+  const [removeLiquidityButtonDisabled, setRemoveLiquidityButtonDisabled] = useState(true)
 
   useEffect(() => {
 
@@ -183,6 +184,14 @@ export const LiquidityPoolTemplate = ({ isMobile }) => {
   }
 
   const handleChangeInput = (value) => {
+    if (value === 0) {
+      setRemoveLiquidityButtonDisabled(true)
+    }
+
+    if (value > 0 && removeLiquidityButtonDisabled) {
+      setRemoveLiquidityButtonDisabled(false)
+    }
+    
     setRemoveLiquidityInput(value)
     handleRemoveCalculation(value)
   }
@@ -363,7 +372,7 @@ const handleActionRemoval = async () => {
             closeCallback={handleRemoveLiquidity}
             liquidityPoolData={removeLiquidityData as any}
             isOpen={showRemoveLiquidityDialog}
-            disabledButton={false}
+            disabledButton={removeLiquidityButtonDisabled}
             disabledAllowanceButton={false}
             showAllowance={(removeLiquidityCalculation.allowance) > 0}
             defaultValue={removeLiquidityInput}

--- a/src/components/templates/LiquidityTemplate/index.tsx
+++ b/src/components/templates/LiquidityTemplate/index.tsx
@@ -82,7 +82,7 @@ export const LiquidityTemplate = ({isMobile}) => {
     })
     const [removeLiquidityInput, setRemoveLiquidityInput] = useState(0)
     const [removeLiquidityToggle, setRemoveLiquidityToggle] = useState(true)
-    const [removeLiquidityButtonEnabled, setRemoveLiquidityButtonEnabled] = useState(false)
+    const [removeLiquidityButtonDisabled, setRemoveLiquidityButtonDisabled] = useState(true)
     const [removeLiquidityAllowanceEnabled, setRemoveLiquidityAllowanceEnabled] = useState(false)
     const [removeLiquidityCalculation, setRemoveLiquidityCalculation] = useState<any>({
         lpAmount: 0,
@@ -93,6 +93,14 @@ export const LiquidityTemplate = ({isMobile}) => {
     const Navigator = useNavigate()
 
     const handleChangeInput = (value) => {
+        if (value === 0) {
+          setRemoveLiquidityButtonDisabled(true)
+        }
+
+        if (value > 0 && removeLiquidityButtonDisabled) {
+          setRemoveLiquidityButtonDisabled(false)
+        }
+        
         setRemoveLiquidityInput(value)
         handleRemoveCalculation(value)
     }
@@ -386,7 +394,7 @@ export const LiquidityTemplate = ({isMobile}) => {
                 closeCallback={handleRemoveLiquidity}
                 liquidityPoolData={removeLiquidityData as any}
                 isOpen={showRemoveLiquidityDialog}
-                disabledButton={removeLiquidityButtonEnabled}
+                disabledButton={removeLiquidityButtonDisabled}
                 disabledAllowanceButton={removeLiquidityAllowanceEnabled}
                 showAllowance={(removeLiquidityCalculation.allowance) > 0}
                 defaultValue={removeLiquidityInput}


### PR DESCRIPTION
![image](https://github.com/Rengo-Labs/uniswap-casper-interface/assets/37820276/1ca7fae1-009f-4de6-91c8-1f4754b4ccd0)
_When the percentage is zero_

![image](https://github.com/Rengo-Labs/uniswap-casper-interface/assets/37820276/46f7e9a6-11bb-45b9-b144-e0c41c3ee8cf)
_Percentage more than zero_


Fixes included in this PR:

- Remove Liquidity button is disabled when the slider percentage is zero.
- The two steps for liquidity removal (allowance and removal) is working for **liquidity pool**
