### PR TITLE
disable remove liquidity btn logic fix on liquidity page

### DIFF
--- a/src/components/templates/LiquidityTemplate/index.tsx
+++ b/src/components/templates/LiquidityTemplate/index.tsx
@@ -151,13 +151,16 @@ export const LiquidityTemplate = ({isMobile}) => {
     }
 
     const handleRemoveLiquidity =  () => {
-        setRemoveLiquidityInput((prevState) => 0)
-        setShowRemoveLiquidityDialog(!showRemoveLiquidityDialog)
+      setRemoveLiquidityButtonDisabled(true)
+      setRemoveLiquidityInput(0)
+      setShowRemoveLiquidityDialog(false)
     }
 
     const onActionRemove = async () => {
       setRemoveLiquidityInput(0)
       setShowRemoveLiquidityDialog(false)
+      setRemoveLiquidityButtonDisabled(true)
+      
       await onRemoveLiquidity(
         removeLiquidityCalculation.lpAmount,
         {


### PR DESCRIPTION
![image](https://github.com/Rengo-Labs/uniswap-casper-interface/assets/37820276/e95638fa-2906-47c9-9e5e-591daafc97b4)

The disable logic is fix for the liquidity removal button for liquidity page