### PR TITLE
add liquidity btn now is enabled even when user cancels the transaction

### DIFF
--- a/src/components/templates/LiquidityTemplate/index.tsx
+++ b/src/components/templates/LiquidityTemplate/index.tsx
@@ -311,16 +311,19 @@ export const LiquidityTemplate = ({isMobile}) => {
 
     async function onLiquidity(amountA, amountB) {
         setIsProcessingTransaction(true)
-        await onAddLiquidity(
+        const isSuccessful = await onAddLiquidity(
             amountA,
             amountB,
             slippageTolerance,
             gasFee
         );
+        
         refresh()
-        amountSwapTokenASetter(0)
-        amountSwapTokenBSetter(0)
         setIsProcessingTransaction(false)
+        if (isSuccessful) {
+          amountSwapTokenASetter(0)
+          amountSwapTokenBSetter(0)
+        }
     }
 
     async function updateLiquidityDetail(


### PR DESCRIPTION
![image](https://github.com/Rengo-Labs/uniswap-casper-interface/assets/37820276/56ed4231-07f9-447f-a32d-519639e553e4)

Add liquidity button is now re enabled when the user cancels the transaction