### PR TITLE
account removal from wallet options

### DIFF
--- a/src/components/organisms/PopupsContainer/index.tsx
+++ b/src/components/organisms/PopupsContainer/index.tsx
@@ -58,14 +58,6 @@ export const PopupsContainer = () => {
 
     const WALLET_CONNECTED_OPTIONS = [
         {
-            id: 'dmx0031b2b421',
-            key: 'account',
-            name: 'My Account',
-            iconName: 'Copy',
-            type: 'Redirect',
-            onClick: () => navigate('/account')
-        },
-        {
             id: '3d23f23xxx88nf',
             key: 'wallet',
             name: walletState.walletAddress,


### PR DESCRIPTION
![image](https://github.com/Rengo-Labs/uniswap-casper-interface/assets/37820276/0669645d-c178-4841-b41e-c14995594ba0)

Description:
Account option removed from wallet options, Copy wallet option its at the top and recent transactions now redirects to account page and set Transfer tab active on transactions table.

QaTouch ID: **[D0051](https://kreitech.qatouch.com/v2/defects/view/p/yVLr/did/61pa7)** 